### PR TITLE
Custom docker images in connectable builds on resin-zc702

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-zc702/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-zc702/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,2 +1,2 @@
-TARGET_REPOSITORY_zc702-zynq7 = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_zc702-zynq7 = "resin/armv7hf-supervisor"
 LED_FILE_zc702-zynq7 = "/sys/class/leds/ds23/brightness"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion
